### PR TITLE
pci: ignore the highest bit in device type

### DIFF
--- a/src/lib/virtio/src/pci.rs
+++ b/src/lib/virtio/src/pci.rs
@@ -140,7 +140,7 @@ impl PciDeviceID {
     pub fn header_type(&self) -> u8 {
         assert_eq!(self.func, 0);
         let res = self.read_config_u32(0x0C);
-        ((res >> 16) & 0xFF) as u8
+        ((res >> 16) & 0x7F) as u8
     }
 
     // See __pci_find_next_cap_ttl()


### PR DESCRIPTION
As per PCIe Spec v6.1 Sec 7.5.1.1.9 Table 7-7, bit 7 of Header Type register indicates whether it is a multi-function device or not. The OS should ignore this bit when determining whether the device is a regular device (type-0) or a switch (type-1).